### PR TITLE
fix: :memo: fix the README.md example

### DIFF
--- a/.changelog/02.txt
+++ b/.changelog/02.txt
@@ -1,0 +1,2 @@
+fix
+Fix the README.md example

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const messageChannel = new MessageChannel();
 
 global.importMapPort = messageChannel.port1;
 
-register("@node-loader/import-maps", {
+register("@node-loader/import-maps", import.meta.url, {
   data: {
     // optional, provides a way to update the import map later on
     port: messageChannel.port2,


### PR DESCRIPTION
fix the README.md example, to match the arguments in register function as in test, for the new v2

Because using the current example will throw error like; 
TypeError [ERR_UNSUPPORTED_RESOLVE_REQUEST]: Failed to resolve module specifier "@node-loader/import-maps" from "data:": Invalid relative URL or base scheme is not hierarchical.